### PR TITLE
mmc/sdio: add sdio_buf for debugging

### DIFF
--- a/drivers/mmc/core/Kconfig
+++ b/drivers/mmc/core/Kconfig
@@ -11,3 +11,11 @@ config MMC_CLKGATE
 	  support handling this in order for it to be of any use.
 
 	  If unsure, say N.
+
+config SDIO_DEBUG_BUFFER
+	bool "MMC debug buffer"
+	depends on DEBUG_FS
+	help
+	  Log Data send/received over the sdio bus for debugging purpose.
+
+	  If unsure, say N.

--- a/drivers/mmc/core/core.h
+++ b/drivers/mmc/core/core.h
@@ -85,6 +85,13 @@ void mmc_remove_host_debugfs(struct mmc_host *host);
 void mmc_add_card_debugfs(struct mmc_card *card);
 void mmc_remove_card_debugfs(struct mmc_card *card);
 
+int mmc_alloc_sdio_buf_debugfs(struct mmc_host *host);
+void mmc_free_sdio_buf_debugfs(struct mmc_host *host);
+void mmc_add_cmd2buf_debugfs(struct mmc_host *host, unsigned int addr, int sz, int write, u8 *w, u8 *r, int ret);
+
+void mmc_sdio_buf_start_recording(struct mmc_host *host);
+void mmc_sdio_buf_stop_recording(struct mmc_host *host);
+
 void mmc_init_context_info(struct mmc_host *host);
 
 int mmc_execute_tuning(struct mmc_card *card);

--- a/drivers/mmc/core/host.c
+++ b/drivers/mmc/core/host.c
@@ -515,6 +515,13 @@ struct mmc_host *mmc_alloc_host(int extra, struct device *dev)
 	host->max_blk_size = 512;
 	host->max_blk_count = PAGE_CACHE_SIZE / 512;
 
+	if ((err = mmc_alloc_sdio_buf_debugfs(host))) {
+		dev_err(&host->class_dev, "alloc of cmd buf failed with %i\n",
+				err);
+		put_device(&host->class_dev);
+		return NULL;
+	}
+
 	return host;
 }
 
@@ -588,6 +595,7 @@ EXPORT_SYMBOL(mmc_remove_host);
  */
 void mmc_free_host(struct mmc_host *host)
 {
+	mmc_free_sdio_buf_debugfs(host);
 	mmc_pwrseq_free(host);
 	put_device(&host->class_dev);
 }

--- a/drivers/mmc/core/sdio_io.c
+++ b/drivers/mmc/core/sdio_io.c
@@ -15,6 +15,7 @@
 #include <linux/mmc/sdio.h>
 #include <linux/mmc/sdio_func.h>
 
+#include "core.h"
 #include "sdio_ops.h"
 
 /**
@@ -373,6 +374,9 @@ u8 sdio_readb(struct sdio_func *func, unsigned int addr, int *err_ret)
 		*err_ret = 0;
 
 	ret = mmc_io_rw_direct(func->card, 0, func->num, addr, 0, &val);
+#ifdef CONFIG_SDIO_DEBUG_BUFFER
+	mmc_add_cmd2buf_debugfs(func->card->host, addr, 1, 0, NULL, &val, ret);
+#endif
 	if (ret) {
 		if (err_ret)
 			*err_ret = ret;
@@ -401,6 +405,9 @@ void sdio_writeb(struct sdio_func *func, u8 b, unsigned int addr, int *err_ret)
 	BUG_ON(!func);
 
 	ret = mmc_io_rw_direct(func->card, 1, func->num, addr, b, NULL);
+#ifdef CONFIG_SDIO_DEBUG_BUFFER
+	mmc_add_cmd2buf_debugfs(func->card->host, addr, 1, 1, &b, NULL, ret);
+#endif
 	if (err_ret)
 		*err_ret = ret;
 }
@@ -427,6 +434,9 @@ u8 sdio_writeb_readb(struct sdio_func *func, u8 write_byte,
 
 	ret = mmc_io_rw_direct(func->card, 1, func->num, addr,
 			write_byte, &val);
+#ifdef CONFIG_SDIO_DEBUG_BUFFER
+	mmc_add_cmd2buf_debugfs(func->card->host, addr, 1, 1, &write_byte, &val, ret);
+#endif
 	if (err_ret)
 		*err_ret = ret;
 	if (ret)
@@ -449,7 +459,11 @@ EXPORT_SYMBOL_GPL(sdio_writeb_readb);
 int sdio_memcpy_fromio(struct sdio_func *func, void *dst,
 	unsigned int addr, int count)
 {
-	return sdio_io_rw_ext_helper(func, 0, addr, 1, dst, count);
+	int ret = sdio_io_rw_ext_helper(func, 0, addr, 1, dst, count);
+#ifdef CONFIG_SDIO_DEBUG_BUFFER
+	mmc_add_cmd2buf_debugfs(func->card->host, addr, count, 0, NULL, dst, ret);
+#endif
+	return ret;
 }
 EXPORT_SYMBOL_GPL(sdio_memcpy_fromio);
 
@@ -466,7 +480,11 @@ EXPORT_SYMBOL_GPL(sdio_memcpy_fromio);
 int sdio_memcpy_toio(struct sdio_func *func, unsigned int addr,
 	void *src, int count)
 {
-	return sdio_io_rw_ext_helper(func, 1, addr, 1, src, count);
+	int ret = sdio_io_rw_ext_helper(func, 1, addr, 1, src, count);
+#ifdef CONFIG_SDIO_DEBUG_BUFFER
+	mmc_add_cmd2buf_debugfs(func->card->host, addr, count, 1, &src, NULL, ret);
+#endif
+	return ret;
 }
 EXPORT_SYMBOL_GPL(sdio_memcpy_toio);
 
@@ -483,7 +501,11 @@ EXPORT_SYMBOL_GPL(sdio_memcpy_toio);
 int sdio_readsb(struct sdio_func *func, void *dst, unsigned int addr,
 	int count)
 {
-	return sdio_io_rw_ext_helper(func, 0, addr, 0, dst, count);
+	int ret = sdio_io_rw_ext_helper(func, 0, addr, 0, dst, count);
+#ifdef CONFIG_SDIO_DEBUG_BUFFER
+	mmc_add_cmd2buf_debugfs(func->card->host, addr, count, 0, NULL, dst, ret);
+#endif
+	return ret;
 }
 EXPORT_SYMBOL_GPL(sdio_readsb);
 
@@ -500,7 +522,11 @@ EXPORT_SYMBOL_GPL(sdio_readsb);
 int sdio_writesb(struct sdio_func *func, unsigned int addr, void *src,
 	int count)
 {
-	return sdio_io_rw_ext_helper(func, 1, addr, 0, src, count);
+	int ret = sdio_io_rw_ext_helper(func, 1, addr, 0, src, count);
+#ifdef CONFIG_SDIO_DEBUG_BUFFER
+	mmc_add_cmd2buf_debugfs(func->card->host, addr, count, 1, &src, NULL, ret);
+#endif
+	return ret;
 }
 EXPORT_SYMBOL_GPL(sdio_writesb);
 
@@ -629,6 +655,9 @@ unsigned char sdio_f0_readb(struct sdio_func *func, unsigned int addr,
 		*err_ret = 0;
 
 	ret = mmc_io_rw_direct(func->card, 0, 0, addr, 0, &val);
+#ifdef CONFIG_SDIO_DEBUG_BUFFER
+	mmc_add_cmd2buf_debugfs(func->card->host, addr, 1, 0, NULL, &val, ret);
+#endif
 	if (ret) {
 		if (err_ret)
 			*err_ret = ret;

--- a/include/linux/mmc/host.h
+++ b/include/linux/mmc/host.h
@@ -355,6 +355,7 @@ struct mmc_host {
 	struct mmc_supply	supply;
 
 	struct dentry		*debugfs_root;
+	void			*sdio_buf;
 
 	struct mmc_async_req	*areq;		/* active async req */
 	struct mmc_context_info	context_info;	/* async synchronization info */


### PR DESCRIPTION
enable recording of sdio_read/write commands for debugging purpouse.
recorded data is accessable over debugfs

Signed-off-by: Matthias Rabe matthias.rabe@sigma-chemnitz.de
